### PR TITLE
fix: truncate only tests, not queries

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Darwin Tests Extension",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Displays and copies darwin tests",
   "permissions": ["clipboardWrite", "contextMenus", "tabs", "scripting"],
   "action": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "darwin-tests-chrome",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "darwin-tests-chrome",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.35.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "darwin-tests-chrome",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Darwin Tests - Chrome Extension",
-  "main": "popup.js",
+  "main": "src/main.js",
   "scripts": {
-    "dev": ""
+    "test": "npx playwright test --ui"
   },
   "author": "Michal Banas",
   "license": "ISC",

--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,7 @@
     <ul id="queries"></ul>
     <footer>
       <p>
-        Darwin A/B Tests, version 0.6.0, developed and tested with <span id="heart-icon">♡</span> by
+        Darwin A/B Tests, version 0.6.1, developed and tested with <span id="heart-icon">♡</span> by
         Michal Banas
       </p>
     </footer>

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,7 +4,7 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.action.setTitle({ title: "Click to open Darwin Test Extension" })
   chrome.contextMenus.create({
     id: "extension-version",
-    title: "Darwin Test Extension v0.5.0",
+    title: "Darwin Test Extension v0.6.1",
     contexts: ["all"],
   })
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -36,6 +36,11 @@ export function createListItem(query, copyQueryToClipboard, addQueryToUrl) {
 export function getTruncatedText(query) {
   const queryLengthMax = 80
   const equalIndex = query.indexOf("=")
+
+  if (!query.includes("mock")) {
+    return query
+  }
+
   const displayText =
     query.length < queryLengthMax
       ? query.substring(equalIndex + 1)


### PR DESCRIPTION
**Changelog** 🚀

- truncate only ab tests value, not queries
- add test script

Close #23 