### PR TITLE
fix: horizontal scrollbar is not shown when usb mouse is plugged in

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Darwin Tests Extension",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "action": {
     "default_popup": "popup.html"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "darwin-tests-chrome",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "darwin-tests-chrome",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.35.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "darwin-tests-chrome",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Darwin Tests - Chrome Extension",
   "main": "src/main.js",
   "type": "module",

--- a/popup.html
+++ b/popup.html
@@ -26,7 +26,7 @@
     </main>
     <footer>
       <p>
-        Darwin A/B Tests, version 0.7.0, developed and tested with <span id="heart-icon">♡</span> by
+        Darwin A/B Tests, version 0.7.1, developed and tested with <span id="heart-icon">♡</span> by
         Michal Banas
       </p>
     </footer>

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,7 +4,7 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.action.setTitle({ title: "Click to open Darwin Test Extension" })
   chrome.contextMenus.create({
     id: "extension-version",
-    title: "Darwin Test Extension v0.7.0",
+    title: "Darwin Test Extension v0.7.1",
     contexts: ["all"],
   })
 

--- a/style.css
+++ b/style.css
@@ -41,7 +41,7 @@ h1 {
 
 ul {
   padding-inline-start: 0;
-  overflow: scroll;
+  overflow-y: scroll;
   height: 310px;
   margin-block-start: 0;
 }


### PR DESCRIPTION
There's issue for macOS users when both (vertical and horizontal) scrollbars are displayed in case that usb mouse is connect. Fixing it here. 