### PR TITLE
no age shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,6 @@
     "type": "module"
   },
   "homepage_url": "https://www.michalbanas.dev/",
-  "minimum_chrome_version": "114",
+  "minimum_chrome_version": "1",
   "permissions": ["activeTab", "clipboardWrite", "contextMenus", "tabs", "scripting", "storage"]
 }


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version ___+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)